### PR TITLE
Feat/api test endpoint

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -2,5 +2,5 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-
+    path('test/', views.test_api, name='api-test'),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,16 @@
 from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 
-# Create your views here.
+@api_view(['GET'])
+def test_api(request):
+    """
+    A simple API view to test if the backend is working.
+    """
+
+    data = {
+        'message': 'Hello from the timetracker API!',
+        'status': 'success',
+        'timestamp': '2024-06-15T12:00:00Z'
+    }
+    return Response(data)

--- a/config/settings.py
+++ b/config/settings.py
@@ -112,3 +112,8 @@ STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+REST_FRAMEWORK = {
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+    ],
+}

--- a/config/settings.py
+++ b/config/settings.py
@@ -28,11 +28,12 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     
-    # Custom
-    
-    'api',
+    # Third-party apps
     'rest_framework',
-    'crosheaders'
+    'corsheaders',
+
+    # Local apps
+    'api',
 ]
 
 MIDDLEWARE = [
@@ -110,3 +111,4 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+


### PR DESCRIPTION
This PR adds a basic test endpoint to verify the API is working correctly.

## Changes
- Configure Django REST Framework in settings
- Create `/api/test/` endpoint that returns JSON
- Establish basic API response structure

## Testing
- Endpoint accessible at `/api/test/`
- Returns proper JSON response
- Confirms DRF integration works
